### PR TITLE
Fix crash when first launch and press 'down'

### DIFF
--- a/src/CommandHistory.cpp
+++ b/src/CommandHistory.cpp
@@ -104,8 +104,10 @@ void CommandHistory::removeAt(int index) {
 }
 
 void CommandHistory::getAllItem(QList<CatItem>& searchResults) const {
-    int64_t index = 0;
-    foreach (InputDataList historyItem, m_history) {
+    int index = 0;
+    for(InputDataList historyItem: m_history) {
+        if(historyItem.isEmpty())
+            continue;
         CatItem& item = historyItem.first().getTopResult();
         item.pluginId = HASH_HISTORY;
         item.data = (void*)index++; // use this when switching alternative list


### PR DESCRIPTION
How to reproduce: fresh install on new system, launch app and press `down` key.
1) When no history is present (i. e. first program launch), `InputDataList::first()` makes access vialoation.
Also I changed 2 other lines:
2) Replaced `foreach` with `for`, because foreach is slower and harder to debug. Is it legacy code from Qt4??
3) Replaced `int64_t index` with `int`. On 32-bit app anyway `item.data = (void*)index++;` will shrink it to sizeof(pointer) whic is 32. On 64 bit, Qt access functions get `int` as parameters, and I doubt that GUI will work ok if you have more than 2 billion entries.