### PR TITLE
Partial build fixes on linux with cmake

### DIFF
--- a/deps/QHotkey/QHotkey
+++ b/deps/QHotkey/QHotkey
@@ -1,1 +1,1 @@
-#include "qhotkey.h"
+#include "QHotkey.h"

--- a/deps/QHotkey/QHotkey.cpp
+++ b/deps/QHotkey/QHotkey.cpp
@@ -1,4 +1,4 @@
-#include "qhotkey.h"
+#include "QHotkey.h"
 #include "qhotkey_p.h"
 #include <QCoreApplication>
 #include <QAbstractEventDispatcher>

--- a/deps/QHotkey/qhotkey_p.h
+++ b/deps/QHotkey/qhotkey_p.h
@@ -1,7 +1,7 @@
 #ifndef QHOTKEY_P_H
 #define QHOTKEY_P_H
 
-#include "qhotkey.h"
+#include "QHotkey.h"
 #include <QAbstractNativeEventFilter>
 #include <QMultiHash>
 #include <QMutex>

--- a/deps/QHotkey/qhotkey_x11.cpp
+++ b/deps/QHotkey/qhotkey_x11.cpp
@@ -1,4 +1,4 @@
-#include "qhotkey.h"
+#include "QHotkey.h"
 #include "qhotkey_p.h"
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 2, 0)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,7 +32,7 @@ if (WIN32)
   message (STATUS "CMAKE_PREFIX_PATH $ENV{CMAKE_PREFIX_PATH}")
   find_package (Qt6 COMPONENTS Widgets Network LinguistTools REQUIRED)
 else ()
-  find_package (Qt6 COMPONENTS Widgets X11Extras Network LinguistTools REQUIRED)
+  find_package (Qt6 COMPONENTS Widgets Network LinguistTools REQUIRED)
   find_package (PkgConfig REQUIRED)
   pkg_check_modules (X11 x11 xcb REQUIRED)
 endif ()
@@ -201,7 +201,7 @@ else ()
 target_link_libraries (Launchy
   LaunchyLib PluginPy
   SingleApplication QHotKey
-  Qt6::Widgets Qt6::X11Extras Qt6::Network)
+  Qt6::Widgets Qt6::Network Qt6::GuiPrivate)
 endif ()
 
 ##################################################
@@ -300,7 +300,7 @@ add_subdirectory(${DEPS_DIR}/SingleApplication SingleApplication)
 # QHotKey
 add_library (QHotKey STATIC)
 
-target_sources (QHotKey PRIVATE ${DEPS_DIR}/QHotkey/qhotkey.cpp)
+target_sources (QHotKey PRIVATE ${DEPS_DIR}/QHotkey/QHotkey.cpp)
 
 if (WIN32)
   target_sources(QHotKey PRIVATE ${DEPS_DIR}/QHotkey/qhotkey_win.cpp)

--- a/src/Launchy/AppBase.h
+++ b/src/Launchy/AppBase.h
@@ -24,7 +24,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <QString>
 #include <QFileIconProvider>
 
-#include <SingleApplication/Singleapplication>
+#include <SingleApplication/SingleApplication>
 
 #include "Directory.h"
 

--- a/src/Launchy/Linux/AppLinux.cpp
+++ b/src/Launchy/Linux/AppLinux.cpp
@@ -23,8 +23,9 @@
 #include <X11/Xlib.h>
 #include <QtGui>
 #include <QApplication>
-#include <QX11Info>
 #include <QFileIconProvider>
+#include <QRegularExpression>
+#include <private/qtx11extras_p.h>
 #include "AppBase.h"
 #include "Catalog.h"
 #include "LaunchyWidget.h"
@@ -167,8 +168,8 @@ void AppLinux::alterItem(CatItem* item) {
 
     if (name.size() >= item->shortName.size() - 8) {
         item->shortName = name;
-        item->searchName[CatItem::LOWER] = item->shortName.toLower();
-        item->searchName[CatItem::TRANS] = CatItem::convertSearchName(item->searchName[CatItem::LOWER]);
+//        item->searchName[CatItem::LOWER] = item->shortName.toLower();
+//        item->searchName[CatItem::TRANS] = CatItem::convertSearchName(item->searchName[CatItem::LOWER]);
     }
 
     // Don't index desktop items wthout icons
@@ -181,7 +182,7 @@ void AppLinux::alterItem(CatItem* item) {
     exe.replace("%c", name);
     exe.replace("%k", item->fullPath);
 
-    QStringList allExe = exe.trimmed().split(" ", QString::SkipEmptyParts);
+    QStringList allExe = exe.trimmed().split(" ", Qt::SkipEmptyParts);
     if (allExe.isEmpty() || allExe[0].isEmpty()) {
         return;
     }
@@ -193,7 +194,7 @@ void AppLinux::alterItem(CatItem* item) {
     /* if an absolute or relative path is supplied we can just skip this
        everything else should be checked to avoid picking up [unwanted]
        stuff from the working directory - if it doesnt exsist, use it anyway */
-    if(!exe.contains(QRegExp("^.?.?/"))) {
+    if(!exe.contains(QRegularExpression("^.?.?/"))) {
         foreach(QString line, QProcess::systemEnvironment()) {
             if (!line.startsWith("Path", Qt::CaseInsensitive)) {
                 continue;

--- a/src/LaunchyLib/LaunchyLib.cpp
+++ b/src/LaunchyLib/LaunchyLib.cpp
@@ -24,6 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <QLocale>
 #include <QProcess>
 #include <QProcessEnvironment>
+#include <QRegularExpression>
 
 #include "PluginMsg.h"
 
@@ -191,7 +192,7 @@ void runProgram(const QString& file, const QString& args, bool translateSeparato
         path.replace("%F", arg);
         path.replace("%f", arg);
         /* remove specifiers either not yet supported or depricated */
-        path.remove(QRegExp("%."));
+        path.remove(QRegularExpression("%."));
         arg = "";
     }
 


### PR DESCRIPTION
- Fixed filename capitalizations in includes (qhotkey.h -> QHotkey.h, SingleApplication/Singleapplication -> SingleApplication/SingleApplication)
- Fixed QRegExp usage
- X11Extras removed in Qt6, replaced with private/qtx11extras_p.h, and Qt6::GuiPrivate

TODO:

These errors not fixed:

src/Launchy/Linux/AppLinux.cpp:170:35: error: ‘LOWER’ is not a member of ‘launchy::CatItem’
  170 |         item->searchName[CatItem::LOWER] = item->shortName.toLower();
      |                                   ^~~~~
src/Launchy/Linux/AppLinux.cpp:171:35: error: ‘TRANS’ is not a member of ‘launchy::CatItem’
  171 |         item->searchName[CatItem::TRANS] = CatItem::convertSearchName(item->searchName[CatItem::LOWER]);
      |                                   ^~~~~
/src/Launchy/Linux/AppLinux.cpp:171:97: error: ‘LOWER’ is not a member of ‘launchy::CatItem’

Linker error:

/bin/ld: lib/libQHotKey.a(QHotkey.cpp.o): in function `QHotkeyPrivate::~QHotkeyPrivate()':
QHotkey.cpp:(.text+0xff2): undefined reference to `vtable for QHotkeyPrivate'
/bin/ld: lib/libQHotKey.a(QHotkey.cpp.o): in function `QHotkeyPrivate::QHotkeyPrivate()':
QHotkey.cpp:(.text+0x12bd): undefined reference to `vtable for QHotkeyPrivate'
/bin/ld: lib/libQHotKey.a(qhotkey_x11.cpp.o):(.data.rel.ro._ZTI17QHotkeyPrivateX11[_ZTI17QHotkeyPrivateX11]+0x10): undefined reference to `typeinfo for QHotkeyPrivate'
/bin/ld: lib/libQHotKey.a(qhotkey_x11.cpp.o):(.data.rel.ro._ZTV17QHotkeyPrivateX11[_ZTV17QHotkeyPrivateX11]+0x10): undefined reference to `QHotkeyPrivate::metaObject() const'
/bin/ld: lib/libQHotKey.a(qhotkey_x11.cpp.o):(.data.rel.ro._ZTV17QHotkeyPrivateX11[_ZTV17QHotkeyPrivateX11]+0x18): undefined reference to `QHotkeyPrivate::qt_metacast(char const*)'
/bin/ld: lib/libQHotKey.a(qhotkey_x11.cpp.o):(.data.rel.ro._ZTV17QHotkeyPrivateX11[_ZTV17QHotkeyPrivateX11]+0x20): undefined reference to `QHotkeyPrivate::qt_metacall(QMetaObject::Call, int, void**)'
collect2: error: ld returned 1 exit status

